### PR TITLE
Updated homepage in cabal file.

### DIFF
--- a/opaleye-trans.cabal
+++ b/opaleye-trans.cabal
@@ -2,7 +2,7 @@ name:                opaleye-trans
 version:             0.3.1
 synopsis:            A monad transformer for Opaleye
 description:         A monad transformer for Opaleye
-homepage:            https://github.com/tomjaguarpaw/haskell-opaleye
+homepage:            https://github.com/WraithM/opaleye-trans
 license:             BSD3
 license-file:        LICENSE
 author:              Matthew Wraith


### PR DESCRIPTION
Update the homepage in the .cabal file to point to https://github.com/WraithM/opaleye-trans instead of https://github.com/tomjaguarpaw/haskell-opaleye
